### PR TITLE
refactor(controllers): alter aliens controllers by registered user

### DIFF
--- a/controllers/aliens.js
+++ b/controllers/aliens.js
@@ -1,48 +1,65 @@
 const Alien = require('../models/alien');
 const asyncWrapper = require('../middleware/async');
+const StatusCodes = require('http-status-codes');
+const NotFoundError = require('../errors/not-found');
 
 const getAllAliens = asyncWrapper(async (req, res) => {
-  const aliens = await Alien.find({});
-  res.status(200).json({ aliens });
+  const aliens = await Alien.find({ createdBy: req.user.userId });
+  res.status(StatusCodes.OK).json({ aliens });
 });
 
 const createAlien = asyncWrapper(async (req, res) => {
+  req.body.createdBy = req.user.userId;
   const alien = await Alien.create(req.body);
-  res.status(201).json({ alien });
+
+  res.status(StatusCodes.CREATED).json({ alien });
 });
 
 const getAlien = asyncWrapper(async (req, res) => {
-  const { id: alienID } = req.params;
-  const alien = await Alien.findOne({ _id: alienID });
-  if (alien) {
-    res.status(200).json({ alien });
-  } else {
-    res.status(404).json({ msg: `No alien with id: ${alienID}` });
+  const { id: alienId } = req.params;
+
+  const alien = await Alien.findOne({
+    _id: alienId,
+    createdBy: req.user.userId,
+  });
+
+  if (!alien) {
+    throw new NotFoundError(`No alien with id: ${alienId}`);
   }
+  res.status(StatusCodes.OK).json({ alien });
 });
 
 const updateAlien = asyncWrapper(async (req, res) => {
-  const { id: alienID } = req.params;
-  const { body } = req;
-  const alien = await Alien.findOneAndUpdate({ _id: alienID }, body, {
-    new: true,
-    runValidators: true,
-  });
-  if (alien) {
-    res.status(200).json({ alien });
-  } else {
-    res.status(404).json({ msg: `No alien with id: ${alienID}` });
+  const { id: alienId } = req.params;
+
+  const alien = await Alien.findOneAndUpdate(
+    { _id: alienId, createdBy: req.user.userId },
+    req.body,
+    { returnDocument: 'after', runValidators: true },
+  );
+
+  if (!alien) {
+    throw new NotFoundError(`No alien with id ${alienId}`);
   }
+
+  res.status(StatusCodes.OK).json({ alien });
 });
 
 const deleteAlien = asyncWrapper(async (req, res) => {
-  const { id: alienID } = req.params;
-  const alien = await Alien.findOneAndDelete({ _id: alienID });
-  if (alien) {
-    res.status(200).json({ alien });
-  } else {
-    res.status(404).json({ msg: `No alien with id: ${alienID}` });
+  const { id: alienId } = req.params;
+
+  const alien = await Alien.findOneAndDelete({
+    _id: alienId,
+    createdBy: req.user.userId,
+  });
+
+  if (!alien) {
+    throw new NotFoundError(`No alien with id ${alienId}`);
   }
+
+  res.status(StatusCodes.OK).json({
+    msg: 'Alien deleted successfully.',
+  });
 });
 
 module.exports = {

--- a/controllers/aliens.js
+++ b/controllers/aliens.js
@@ -1,6 +1,6 @@
+const StatusCodes = require('http-status-codes');
 const Alien = require('../models/alien');
 const asyncWrapper = require('../middleware/async');
-const StatusCodes = require('http-status-codes');
 const NotFoundError = require('../errors/not-found');
 
 const getAllAliens = asyncWrapper(async (req, res) => {

--- a/errors/not-found.js
+++ b/errors/not-found.js
@@ -1,10 +1,10 @@
 const StatusCodes = require('http-status-codes');
 const CustomErrorAPI = require('./custom-error');
 
-class NotFound extends CustomErrorAPI {
+class NotFoundError extends CustomErrorAPI {
   constructor(message, statusCode = StatusCodes.BAD_REQUEST) {
     super(message, statusCode);
   }
 }
 
-module.exports = NotFound;
+module.exports = NotFoundError;

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -12,7 +12,7 @@ const authentication = async (req, res, next) => {
 
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = { userId: payload._id, name: payload.name };
+    req.user = { userId: payload.userId, name: payload.name };
     return next();
   } catch (error) {
     return next(new UnauthenticatedError('Authentication invalid'));

--- a/models/alien.js
+++ b/models/alien.js
@@ -5,7 +5,6 @@ const AlienSchema = new mongoose.Schema({
     type: String,
     trim: true,
     required: [true, 'Please provide name'],
-    unique: true,
     validate: {
       validator: (v) => v && v.trim().length > 0,
       message: 'Name cannot be empty',

--- a/models/alien.js
+++ b/models/alien.js
@@ -20,6 +20,11 @@ const AlienSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  createdBy: {
+    type: mongoose.Types.ObjectId,
+    ref: 'User',
+    required: [true, 'Please provide user'],
+  },
 });
 
 module.exports = mongoose.model('Alien', AlienSchema);


### PR DESCRIPTION
## What & Why
Refactor aliens controllers to perform CRUD functionalities by registered and logged-in users. 

## Changes Made
- Added `createdBy` on alien schema
- Leverage `http-status-codes` on each controller instead of hard-coding HTTP status 
- Refactor all CRUD controllers to only be accessible to registered User
- Enforced conventional commits via commitlint + husky

## How to Test
Register & Login user and with Bearer token:
1. `GET /api/v1/aliens` 
2. `GET/api/v1/aliens/:id` with valid or invalid id
3. `PATCH /api/v1/aliens/:id` with correct and wrong body 
4. `POST/api/v1/aliens` with correct and wrong body
5. `DELETE/api/v1/aliens/:id`  with valid or invalid id
6. Verify validation errors return 400, not 500

## Screenshots (if applicable)
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/4b9e3ce9-31bc-47c8-bad6-687bbdfac2e4" />

## Notes / Concerns
- Passwords are hashed with bcrypt before saving

